### PR TITLE
Added compat section to Project.toml

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -34,9 +34,9 @@ version = "2.3.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "a706ff10f1cd8dab94f59fd09c0e657db8e77ff0"
+git-tree-sha1 = "2724ac91f1334c8e5c10565faad5afeafd1bfc89"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.23.0"
+version = "3.24.0"
 
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,3 +7,7 @@ version = "0.1.0"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[compat]
+CUDA = "2.3.0"
+julia = "1.5"


### PR DESCRIPTION
I added `[compat]` section to `Project.toml`.

@youngdae @frapac I also see that `.toml` files are separately in `test` directory. Is this a new convention? Instead of using `[extras]` and `[targets]` sections?