### PR TITLE
Add function to transfer data between callbacks and matrices

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -207,6 +207,7 @@ function solveProblem(tron::ExaTronProblem)
     tron.nfev = tron.ngev = tron.nhev = 0
     tron.status = :NotSolved
     search = true
+
     while (search)
 
         # Evaluate the function.
@@ -231,21 +232,7 @@ function solveProblem(tron::ExaTronProblem)
 
             # Copy values in the CSC matrix.
             fill!(tron.A, 0.0)
-            if tron.options["matrix_type"] == :Sparse
-                @inbounds for i in 1:tron.nnz
-                    m = tron.A.map[i]
-                    if m < 0
-                        tron.A.diag_vals[-m] += tron.values[i]
-                    else
-                        tron.A.tril_vals[m] += tron.values[i]
-                    end
-                end
-            else
-                @inbounds for i in 1:tron.nnz
-                    # It is assumed that rows[i] >= cols[i] for all i.
-                    tron.A.vals[tron.rows[i], tron.cols[i]] += tron.values[i]
-                end
-            end
+            transfer!(tron.A, tron.rows, tron.cols, tron.values, tron.nnz)
         end
 
         # Initialize the trust region bound.

--- a/src/dssyax.jl
+++ b/src/dssyax.jl
@@ -143,14 +143,20 @@ function Base.fill!(A::TronSparseMatrixCSC, val)
     fill!(A.tril_vals, val)
 end
 
-function Base.copy!(A::TronSparseMatrixCSC, values)
-    for i in 1:A.nnz
+function transfer!(A::TronSparseMatrixCSC, rows, cols, values, nnz)
+    for i in 1:nnz
         m = A.map[i]
         if m < 0
             A.diag_vals[-m] = values[i]
         else
             A.tril_vals[m] = values[i]
         end
+    end
+end
+function transfer!(A::TronDenseMatrix, rows, cols, values, nnz)
+    @inbounds for i in 1:nnz
+        # It is assumed that rows[i] >= cols[i] for all i.
+        A.vals[rows[i], cols[i]] += values[i]
     end
 end
 

--- a/test/qptest.jl
+++ b/test/qptest.jl
@@ -7,7 +7,7 @@ function build_problem(; n=10)
     l = - 100. * rand(n)
     Iz, Jz, vals = findnz(P)
 
-    eval_f(x) = 0.5 * x' * P * x + q' * x
+    eval_f(x) = 0.5 * dot(x, P, x) + dot(q, x)
 
     function eval_g(x, g)
         fill!(g, 0)


### PR DESCRIPTION
Before that PR, the data transfer occurred directly in the main function, preventing Julia compiler to infer type properly. This resulted in additional --- and unwanted --- allocations. A quick profiling using `BenchmarkTools` gives on `main`: 
```
julia> include("profiling/qptest.jl")
  520.067 μs (6005 allocations: 141.88 KiB)
:Solve_Succeeded
```
By moving the transfer routine in a separate function, we allow a better specialization in the compiler, and a decrease in a number of allocations as types are inferred properly. With this PR, we get:
```julia
julia> include("profiling/qptest.jl")
  177.643 μs (49 allocations: 33.17 KiB)
:Solve_Succeeded
```

See #10 